### PR TITLE
force int conversion in rgb_prepare

### DIFF
--- a/husl.py
+++ b/husl.py
@@ -133,7 +133,7 @@ def rgb_prepare(triple):
         if ch < 0: ch = 0
         if ch > 1: ch = 1
 
-        ret.append(round(ch * 255, 0))
+        ret.append(int(round(ch * 255, 0)))
 
     return ret
 


### PR DESCRIPTION
this fixes a bug that popped up when I was trying to use the husl module. Basically it's converting numbers to a scale of 255 and then calling np.round, but they're left as floats. This means that when they are converted to something like hex with %02x, it was returning an error because it required an int, not a float. This PR just explicitly turns RGB values into int after calling np.round.